### PR TITLE
Schema i18n reactivity

### DIFF
--- a/i18n/errors-i18n.js
+++ b/i18n/errors-i18n.js
@@ -74,7 +74,7 @@ const regExpMessages = function(locale) {
 };
 
 const errorMessages = function(locale) {
-	return {
+	const errors = {
 		required: i18n.__("SimpleSchema.defaults.required", {
 			_locale: locale,
 		}),
@@ -126,18 +126,33 @@ const errorMessages = function(locale) {
 
 			const regExpMessage = msgObj
 				? msgObj.msg
-				: i18n.__("SimpleSchema.regExMsgStubs.msg");
+				: i18n.__("SimpleSchema.regExMsgStubs.msg", {
+						_locale: locale,
+				  });
 
 			return `${label} ${regExpMessage}`;
 		},
 
-		keyNotInSchema: i18n.__("SimpleSchema.defaults.keyNotInSchema"),
+		keyNotInSchema: i18n.__("SimpleSchema.defaults.keyNotInSchema", {
+			_locale: locale,
+		}),
 	};
+	return errors;
 };
+
+const englishDefaults = errorMessages("en");
+const spanishDefaults = errorMessages("es");
+
+if (Meteor.isClient && Meteor.isDevelopment) {
+	console.log("englishDefaults");
+	console.log(englishDefaults);
+	console.log("spanishDefaults");
+	console.log(spanishDefaults);
+}
 
 SimpleSchema.setDefaultMessages({
 	messages: {
-		en: errorMessages("en"),
-		es: errorMessages("es"),
+		en: englishDefaults,
+		es: spanishDefaults,
 	},
 });

--- a/imports/api/data/companies.js
+++ b/imports/api/data/companies.js
@@ -335,42 +335,93 @@ Companies.schema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-Companies.schema.labels({
-	_id: i18n.__("SimpleSchema.labels.Companies._id"),
-	vizeProfileUrl: i18n.__("SimpleSchema.labels.Companies.vizeProfileUrl"),
-	vizeReviewUrl: i18n.__("SimpleSchema.labels.Companies.vizeReviewUrl"),
-	vizeSalaryUrl: i18n.__("SimpleSchema.labels.Companies.vizeSalaryUrl"),
-	vizePostJobUrl: i18n.__("SimpleSchema.labels.Companies.vizePostJobUrl"),
-	name: i18n.__("SimpleSchema.labels.Companies.name"),
-	contactEmail: i18n.__("SimpleSchema.labels.Companies.contactEmail"),
-	dateEstablished: i18n.__("SimpleSchema.labels.Companies.dateEstablished"),
-	numEmployees: i18n.__("SimpleSchema.labels.Companies.numEmployees"),
-	industry: i18n.__("SimpleSchema.labels.Companies.industry"),
-	locations: i18n.__("SimpleSchema.labels.Companies.locations"),
-	otherContactInfo: i18n.__("SimpleSchema.labels.Companies.otherContactInfo"),
-	websiteURL: i18n.__("SimpleSchema.labels.Companies.websiteURL"),
-	descriptionOfCompany: i18n.__(
-		"SimpleSchema.labels.Companies.descriptionOfCompany"
-	),
-	dateJoined: i18n.__("SimpleSchema.labels.Companies.dateJoined"),
-	numFlags: i18n.__("SimpleSchema.labels.Companies.numFlags"),
-	healthAndSafety: i18n.__("SimpleSchema.labels.Companies.healthAndSafety"),
-	managerRelationship: i18n.__(
-		"SimpleSchema.labels.Companies.managerRelationship"
-	),
-	workEnvironment: i18n.__("SimpleSchema.labels.Companies.workEnvironment"),
-	benefits: i18n.__("SimpleSchema.labels.Companies.benefits"),
-	overallSatisfaction: i18n.__(
-		"SimpleSchema.labels.Companies.overallSatisfaction"
-	),
-	numReviews: i18n.__("SimpleSchema.labels.Companies.numReviews"),
-	percentRecommended: i18n.__(
-		"SimpleSchema.labels.Companies.percentRecommended"
-	),
-	avgNumMonthsWorked: i18n.__(
-		"SimpleSchema.labels.Companies.avgNumMonthsWorked"
-	),
-});
+const companyLabels = function() {
+	return {
+		_id: i18n.__("SimpleSchema.labels.Companies._id", {
+			_locale: i18n.getLocale(),
+		}),
+		vizeProfileUrl: i18n.__(
+			"SimpleSchema.labels.Companies.vizeProfileUrl",
+			{ _locale: i18n.getLocale() }
+		),
+		vizeReviewUrl: i18n.__("SimpleSchema.labels.Companies.vizeReviewUrl", {
+			_locale: i18n.getLocale(),
+		}),
+		vizeSalaryUrl: i18n.__("SimpleSchema.labels.Companies.vizeSalaryUrl", {
+			_locale: i18n.getLocale(),
+		}),
+		vizePostJobUrl: i18n.__(
+			"SimpleSchema.labels.Companies.vizePostJobUrl",
+			{ _locale: i18n.getLocale() }
+		),
+		name: i18n.__("SimpleSchema.labels.Companies.name", {
+			_locale: i18n.getLocale(),
+		}),
+		contactEmail: i18n.__("SimpleSchema.labels.Companies.contactEmail", {
+			_locale: i18n.getLocale(),
+		}),
+		dateEstablished: i18n.__(
+			"SimpleSchema.labels.Companies.dateEstablished",
+			{ _locale: i18n.getLocale() }
+		),
+		numEmployees: i18n.__("SimpleSchema.labels.Companies.numEmployees", {
+			_locale: i18n.getLocale(),
+		}),
+		industry: i18n.__("SimpleSchema.labels.Companies.industry", {
+			_locale: i18n.getLocale(),
+		}),
+		locations: i18n.__("SimpleSchema.labels.Companies.locations", {
+			_locale: i18n.getLocale(),
+		}),
+		otherContactInfo: i18n.__(
+			"SimpleSchema.labels.Companies.otherContactInfo",
+			{ _locale: i18n.getLocale() }
+		),
+		websiteURL: i18n.__("SimpleSchema.labels.Companies.websiteURL", {
+			_locale: i18n.getLocale(),
+		}),
+		descriptionOfCompany: i18n.__(
+			"SimpleSchema.labels.Companies.descriptionOfCompany",
+			{ _locale: i18n.getLocale() }
+		),
+		dateJoined: i18n.__("SimpleSchema.labels.Companies.dateJoined", {
+			_locale: i18n.getLocale(),
+		}),
+		numFlags: i18n.__("SimpleSchema.labels.Companies.numFlags", {
+			_locale: i18n.getLocale(),
+		}),
+		healthAndSafety: i18n.__(
+			"SimpleSchema.labels.Companies.healthAndSafety",
+			{ _locale: i18n.getLocale() }
+		),
+		managerRelationship: i18n.__(
+			"SimpleSchema.labels.Companies.managerRelationship",
+			{ _locale: i18n.getLocale() }
+		),
+		workEnvironment: i18n.__(
+			"SimpleSchema.labels.Companies.workEnvironment",
+			{ _locale: i18n.getLocale() }
+		),
+		benefits: i18n.__("SimpleSchema.labels.Companies.benefits", {
+			_locale: i18n.getLocale(),
+		}),
+		overallSatisfaction: i18n.__(
+			"SimpleSchema.labels.Companies.overallSatisfaction",
+			{ _locale: i18n.getLocale() }
+		),
+		numReviews: i18n.__("SimpleSchema.labels.Companies.numReviews", {
+			_locale: i18n.getLocale(),
+		}),
+		percentRecommended: i18n.__(
+			"SimpleSchema.labels.Companies.percentRecommended",
+			{ _locale: i18n.getLocale() }
+		),
+		avgNumMonthsWorked: i18n.__(
+			"SimpleSchema.labels.Companies.avgNumMonthsWorked",
+			{ _locale: i18n.getLocale() }
+		),
+	};
+};
 
 const companyErrorMessages = function(locale) {
 	return {
@@ -383,6 +434,8 @@ const companyErrorMessages = function(locale) {
 const englishCompanies = companyErrorMessages("en");
 const spanishCompanies = companyErrorMessages("es");
 
+Companies.schema.labels(companyLabels());
+
 // Define custom error messages for custom validation functions
 Companies.schema.messageBox.messages({
 	en: englishCompanies,
@@ -392,6 +445,7 @@ Companies.schema.messageBox.messages({
 i18n.onChangeLocale(function(newLocale) {
 	if (Meteor.isDevelopment) console.log("COMPANIES: " + newLocale);
 	Companies.schema.messageBox.setLanguage(newLocale);
+	Companies.schema.labels(companyLabels());
 });
 
 // db.CompanyProfiles.find({$text: {$search: "vize"}}, {score: {$meta: "textScore"}}).sort({score:{$meta:"textScore"}})

--- a/imports/api/data/companies.js
+++ b/imports/api/data/companies.js
@@ -380,16 +380,17 @@ const companyErrorMessages = function(locale) {
 	};
 };
 
+const englishCompanies = companyErrorMessages("en");
+const spanishCompanies = companyErrorMessages("es");
+
 // Define custom error messages for custom validation functions
 Companies.schema.messageBox.messages({
-	// en? does that mean we can add internationalization
-	// in this block of code?
-	en: companyErrorMessages("en"),
-	es: companyErrorMessages("es"),
+	en: englishCompanies,
+	es: spanishCompanies,
 });
 
 i18n.onChangeLocale(function(newLocale) {
-	console.log("COMPANIES: " + newLocale);
+	if (Meteor.isDevelopment) console.log("COMPANIES: " + newLocale);
 	Companies.schema.messageBox.setLanguage(newLocale);
 });
 

--- a/imports/api/data/jobads.js
+++ b/imports/api/data/jobads.js
@@ -176,22 +176,48 @@ JobAds.schema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-JobAds.schema.labels({
-	_id: i18n.__("SimpleSchema.labels.JobAds._id"),
-	companyName: i18n.__("SimpleSchema.labels.JobAds.companyName"),
-	companyId: i18n.__("SimpleSchema.labels.JobAds.companyId"),
-	vizeApplyForJobUrl: i18n.__(
-		"SimpleSchema.labels.JobAds.vizeApplyForJobUrl"
-	),
-	jobTitle: i18n.__("SimpleSchema.labels.JobAds.jobTitle"),
-	locations: i18n.__("SimpleSchema.labels.JobAds.locations"),
-	pesosPerHour: i18n.__("SimpleSchema.labels.JobAds.pesosPerHour"),
-	contractType: i18n.__("SimpleSchema.labels.JobAds.contractType"),
-	jobDescription: i18n.__("SimpleSchema.labels.JobAds.jobDescription"),
-	responsibilities: i18n.__("SimpleSchema.labels.JobAds.responsibilities"),
-	qualifications: i18n.__("SimpleSchema.labels.JobAds.qualifications"),
-	datePosted: i18n.__("SimpleSchema.labels.JobAds.datePosted"),
-});
+const jobAdLabels = function() {
+	return {
+		_id: i18n.__("SimpleSchema.labels.JobAds._id", {
+			_locale: i18n.getLocale(),
+		}),
+		companyName: i18n.__("SimpleSchema.labels.JobAds.companyName", {
+			_locale: i18n.getLocale(),
+		}),
+		companyId: i18n.__("SimpleSchema.labels.JobAds.companyId", {
+			_locale: i18n.getLocale(),
+		}),
+		vizeApplyForJobUrl: i18n.__(
+			"SimpleSchema.labels.JobAds.vizeApplyForJobUrl",
+			{ _locale: i18n.getLocale() }
+		),
+		jobTitle: i18n.__("SimpleSchema.labels.JobAds.jobTitle", {
+			_locale: i18n.getLocale(),
+		}),
+		locations: i18n.__("SimpleSchema.labels.JobAds.locations", {
+			_locale: i18n.getLocale(),
+		}),
+		pesosPerHour: i18n.__("SimpleSchema.labels.JobAds.pesosPerHour", {
+			_locale: i18n.getLocale(),
+		}),
+		contractType: i18n.__("SimpleSchema.labels.JobAds.contractType", {
+			_locale: i18n.getLocale(),
+		}),
+		jobDescription: i18n.__("SimpleSchema.labels.JobAds.jobDescription", {
+			_locale: i18n.getLocale(),
+		}),
+		responsibilities: i18n.__(
+			"SimpleSchema.labels.JobAds.responsibilities",
+			{ _locale: i18n.getLocale() }
+		),
+		qualifications: i18n.__("SimpleSchema.labels.JobAds.qualifications", {
+			_locale: i18n.getLocale(),
+		}),
+		datePosted: i18n.__("SimpleSchema.labels.JobAds.datePosted", {
+			_locale: i18n.getLocale(),
+		}),
+	};
+};
 
 const jobAdErrors = function(locale) {
 	return {
@@ -204,6 +230,8 @@ const jobAdErrors = function(locale) {
 
 const englishJobAds = jobAdErrors("en");
 const spanishJobAds = jobAdErrors("es");
+
+JobAds.schema.labels(jobAdLabels());
 
 JobAds.schema.messageBox.messages({
 	en: englishJobAds,
@@ -328,17 +356,34 @@ JobAds.applicationSchema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-JobAds.applicationSchema.labels({
-	jobId: i18n.__("SimpleSchema.labels.JobApplications.jobId"),
-	companyName: i18n.__("SimpleSchema.labels.JobApplications.companyName"),
-	fullName: i18n.__("SimpleSchema.labels.JobApplications.fullName"),
-	email: i18n.__("SimpleSchema.labels.JobApplications.email"),
-	phoneNumber: i18n.__("SimpleSchema.labels.JobApplications.phoneNumber"),
-	coverLetterAndComments: i18n.__(
-		"SimpleSchema.labels.JobApplications.coverLetterAndComments"
-	),
-	dateSent: i18n.__("SimpleSchema.labels.JobApplications.dateSent"),
-});
+const jobAppLabels = function() {
+	return {
+		jobId: i18n.__("SimpleSchema.labels.JobApplications.jobId", {
+			_locale: i18n.getLocale(),
+		}),
+		companyName: i18n.__(
+			"SimpleSchema.labels.JobApplications.companyName",
+			{ _locale: i18n.getLocale() }
+		),
+		fullName: i18n.__("SimpleSchema.labels.JobApplications.fullName", {
+			_locale: i18n.getLocale(),
+		}),
+		email: i18n.__("SimpleSchema.labels.JobApplications.email", {
+			_locale: i18n.getLocale(),
+		}),
+		phoneNumber: i18n.__(
+			"SimpleSchema.labels.JobApplications.phoneNumber",
+			{ _locale: i18n.getLocale() }
+		),
+		coverLetterAndComments: i18n.__(
+			"SimpleSchema.labels.JobApplications.coverLetterAndComments",
+			{ _locale: i18n.getLocale() }
+		),
+		dateSent: i18n.__("SimpleSchema.labels.JobApplications.dateSent", {
+			_locale: i18n.getLocale(),
+		}),
+	};
+};
 
 const jobAppErrors = function(locale) {
 	return {
@@ -356,6 +401,8 @@ const jobAppErrors = function(locale) {
 const englishJobApps = jobAppErrors("en");
 const spanishJobApps = jobAppErrors("es");
 
+JobAds.applicationSchema.labels(jobAppLabels());
+
 JobAds.applicationSchema.messageBox.messages({
 	en: englishJobApps,
 	es: spanishJobApps,
@@ -366,6 +413,8 @@ i18n.onChangeLocale(function(newLocale) {
 		console.log("JOBADS AND JOBAPPLICATIONS: " + newLocale);
 	JobAds.schema.messageBox.setLanguage(newLocale);
 	JobAds.applicationSchema.messageBox.setLanguage(newLocale);
+	JobAds.schema.labels(jobAdLabels());
+	JobAds.applicationSchema.labels(jobAppLabels());
 });
 
 JobAds.deny({

--- a/imports/api/data/jobads.js
+++ b/imports/api/data/jobads.js
@@ -176,10 +176,6 @@ JobAds.schema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-const jobAdErrors = {
-	noCompanyWithThatName: i18n.__("SimpleSchema.custom.noCompanyWithThatName"),
-};
-
 JobAds.schema.labels({
 	_id: i18n.__("SimpleSchema.labels.JobAds._id"),
 	companyName: i18n.__("SimpleSchema.labels.JobAds.companyName"),
@@ -197,11 +193,21 @@ JobAds.schema.labels({
 	datePosted: i18n.__("SimpleSchema.labels.JobAds.datePosted"),
 });
 
+const jobAdErrors = function(locale) {
+	return {
+		noCompanyWithThatName: i18n.__(
+			"SimpleSchema.custom.noCompanyWithThatName",
+			{ _locale: locale }
+		),
+	};
+};
+
+const englishJobAds = jobAdErrors("en");
+const spanishJobAds = jobAdErrors("es");
+
 JobAds.schema.messageBox.messages({
-	// en? does that mean we can add internationalization
-	// in this block of code?
-	en: jobAdErrors,
-	es: jobAdErrors,
+	en: englishJobAds,
+	es: spanishJobAds,
 });
 
 JobAds.attachSchema(JobAds.schema, { replace: true });
@@ -347,15 +353,17 @@ const jobAppErrors = function(locale) {
 	};
 };
 
+const englishJobApps = jobAppErrors("en");
+const spanishJobApps = jobAppErrors("es");
+
 JobAds.applicationSchema.messageBox.messages({
-	// en? does that mean we can add internationalization
-	// in this block of code?
-	en: jobAppErrors("en"),
-	es: jobAppErrors("es"),
+	en: englishJobApps,
+	es: spanishJobApps,
 });
 
 i18n.onChangeLocale(function(newLocale) {
-	console.log("JOBADS AND JOBAPPLICATIONS: " + newLocale);
+	if (Meteor.isDevelopment)
+		console.log("JOBADS AND JOBAPPLICATIONS: " + newLocale);
 	JobAds.schema.messageBox.setLanguage(newLocale);
 	JobAds.applicationSchema.messageBox.setLanguage(newLocale);
 });

--- a/imports/api/data/reviews.js
+++ b/imports/api/data/reviews.js
@@ -406,15 +406,16 @@ const reviewErrorMessages = function(locale) {
 	};
 };
 
+const englishReviews = reviewErrorMessages("en");
+const spanishReviews = reviewErrorMessages("es");
+
 Reviews.schema.messageBox.messages({
-	// en? does that mean we can add internationalization
-	// in this block of code?
-	en: reviewErrorMessages("en"),
-	es: reviewErrorMessages("es"),
+	en: englishReviews,
+	es: spanishReviews,
 });
 
 i18n.onChangeLocale(function(newLocale) {
-	console.log("REVIEWS: " + newLocale);
+	if (Meteor.isDevelopment) console.log("REVIEWS: " + newLocale);
 	Reviews.schema.messageBox.setLanguage(newLocale);
 });
 

--- a/imports/api/data/reviews.js
+++ b/imports/api/data/reviews.js
@@ -358,38 +358,81 @@ Reviews.schema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-Reviews.schema.labels({
-	_id: i18n.__("SimpleSchema.labels.Reviews._id"),
-	submittedBy: i18n.__("SimpleSchema.labels.Reviews.submittedBy"),
-	companyName: i18n.__("SimpleSchema.labels.Reviews.companyName"),
-	companyId: i18n.__("SimpleSchema.labels.Reviews.companyId"),
-	reviewTitle: i18n.__("SimpleSchema.labels.Reviews.reviewTitle"),
-	locations: i18n.__("SimpleSchema.labels.Reviews.locations"),
-	jobTitle: i18n.__("SimpleSchema.labels.Reviews.jobTitle"),
-	numberOfMonthsWorked: i18n.__(
-		"SimpleSchema.labels.Reviews.numberOfMonthsWorked"
-	),
-	pros: i18n.__("SimpleSchema.labels.Reviews.pros"),
-	cons: i18n.__("SimpleSchema.labels.Reviews.cons"),
-	wouldRecommendToOtherJobSeekers: i18n.__(
-		"SimpleSchema.labels.Reviews.wouldRecommendToOtherJobSeekers"
-	),
-	healthAndSafety: i18n.__("SimpleSchema.labels.Reviews.healthAndSafety"),
-	managerRelationship: i18n.__(
-		"SimpleSchema.labels.Reviews.managerRelationship"
-	),
-	workEnvironment: i18n.__("SimpleSchema.labels.Reviews.workEnvironment"),
-	benefits: i18n.__("SimpleSchema.labels.Reviews.benefits"),
-	overallSatisfaction: i18n.__(
-		"SimpleSchema.labels.Reviews.overallSatisfaction"
-	),
-	additionalComments: i18n.__(
-		"SimpleSchema.labels.Reviews.additionalComments"
-	),
-	datePosted: i18n.__("SimpleSchema.labels.Reviews.datePosted"),
-	upvotes: i18n.__("SimpleSchema.labels.Reviews.upvotes"),
-	downvotes: i18n.__("SimpleSchema.labels.Reviews.downvotes"),
-});
+const reviewLabels = function() {
+	return {
+		_id: i18n.__("SimpleSchema.labels.Reviews._id", {
+			_locale: i18n.getLocale(),
+		}),
+		submittedBy: i18n.__("SimpleSchema.labels.Reviews.submittedBy", {
+			_locale: i18n.getLocale(),
+		}),
+		companyName: i18n.__("SimpleSchema.labels.Reviews.companyName", {
+			_locale: i18n.getLocale(),
+		}),
+		companyId: i18n.__("SimpleSchema.labels.Reviews.companyId", {
+			_locale: i18n.getLocale(),
+		}),
+		reviewTitle: i18n.__("SimpleSchema.labels.Reviews.reviewTitle", {
+			_locale: i18n.getLocale(),
+		}),
+		locations: i18n.__("SimpleSchema.labels.Reviews.locations", {
+			_locale: i18n.getLocale(),
+		}),
+		jobTitle: i18n.__("SimpleSchema.labels.Reviews.jobTitle", {
+			_locale: i18n.getLocale(),
+		}),
+		numberOfMonthsWorked: i18n.__(
+			"SimpleSchema.labels.Reviews.numberOfMonthsWorked",
+			{ _locale: i18n.getLocale() }
+		),
+		pros: i18n.__("SimpleSchema.labels.Reviews.pros", {
+			_locale: i18n.getLocale(),
+		}),
+		cons: i18n.__("SimpleSchema.labels.Reviews.cons", {
+			_locale: i18n.getLocale(),
+		}),
+		wouldRecommendToOtherJobSeekers: i18n.__(
+			"SimpleSchema.labels.Reviews.wouldRecommendToOtherJobSeekers",
+			{ _locale: i18n.getLocale() }
+		),
+		healthAndSafety: i18n.__(
+			"SimpleSchema.labels.Reviews.healthAndSafety",
+			{
+				_locale: i18n.getLocale(),
+			}
+		),
+		managerRelationship: i18n.__(
+			"SimpleSchema.labels.Reviews.managerRelationship",
+			{ _locale: i18n.getLocale() }
+		),
+		workEnvironment: i18n.__(
+			"SimpleSchema.labels.Reviews.workEnvironment",
+			{
+				_locale: i18n.getLocale(),
+			}
+		),
+		benefits: i18n.__("SimpleSchema.labels.Reviews.benefits", {
+			_locale: i18n.getLocale(),
+		}),
+		overallSatisfaction: i18n.__(
+			"SimpleSchema.labels.Reviews.overallSatisfaction",
+			{ _locale: i18n.getLocale() }
+		),
+		additionalComments: i18n.__(
+			"SimpleSchema.labels.Reviews.additionalComments",
+			{ _locale: i18n.getLocale() }
+		),
+		datePosted: i18n.__("SimpleSchema.labels.Reviews.datePosted", {
+			_locale: i18n.getLocale(),
+		}),
+		upvotes: i18n.__("SimpleSchema.labels.Reviews.upvotes", {
+			_locale: i18n.getLocale(),
+		}),
+		downvotes: i18n.__("SimpleSchema.labels.Reviews.downvotes", {
+			_locale: i18n.getLocale(),
+		}),
+	};
+};
 
 const reviewErrorMessages = function(locale) {
 	return {
@@ -409,6 +452,8 @@ const reviewErrorMessages = function(locale) {
 const englishReviews = reviewErrorMessages("en");
 const spanishReviews = reviewErrorMessages("es");
 
+Reviews.schema.labels(reviewLabels());
+
 Reviews.schema.messageBox.messages({
 	en: englishReviews,
 	es: spanishReviews,
@@ -417,6 +462,7 @@ Reviews.schema.messageBox.messages({
 i18n.onChangeLocale(function(newLocale) {
 	if (Meteor.isDevelopment) console.log("REVIEWS: " + newLocale);
 	Reviews.schema.messageBox.setLanguage(newLocale);
+	Reviews.schema.labels(reviewLabels());
 });
 
 Reviews.attachSchema(Reviews.schema, { replace: true });

--- a/imports/api/data/salaries.js
+++ b/imports/api/data/salaries.js
@@ -132,17 +132,35 @@ Salaries.schema = new SimpleSchema(
 	{ tracker: Tracker }
 );
 
-Salaries.schema.labels({
-	_id: i18n.__("SimpleSchema.labels.Salaries._id"),
-	submittedBy: i18n.__("SimpleSchema.labels.Salaries.submittedBy"),
-	companyName: i18n.__("SimpleSchema.labels.Salaries.companyName"),
-	companyId: i18n.__("SimpleSchema.labels.Salaries.companyId"),
-	jobTitle: i18n.__("SimpleSchema.labels.Salaries.jobTitle"),
-	incomeType: i18n.__("SimpleSchema.labels.Salaries.incomeType"),
-	incomeAmount: i18n.__("SimpleSchema.labels.Salaries.incomeAmount"),
-	gender: i18n.__("SimpleSchema.labels.Salaries.gender"),
-	datePosted: i18n.__("SimpleSchema.labels.Salaries.datePosted"),
-});
+const salaryLabels = function() {
+	return {
+		_id: i18n.__("SimpleSchema.labels.Salaries._id"),
+		submittedBy: i18n.__("SimpleSchema.labels.Salaries.submittedBy", {
+			_locale: i18n.getLocale(),
+		}),
+		companyName: i18n.__("SimpleSchema.labels.Salaries.companyName", {
+			_locale: i18n.getLocale(),
+		}),
+		companyId: i18n.__("SimpleSchema.labels.Salaries.companyId", {
+			_locale: i18n.getLocale(),
+		}),
+		jobTitle: i18n.__("SimpleSchema.labels.Salaries.jobTitle", {
+			_locale: i18n.getLocale(),
+		}),
+		incomeType: i18n.__("SimpleSchema.labels.Salaries.incomeType", {
+			_locale: i18n.getLocale(),
+		}),
+		incomeAmount: i18n.__("SimpleSchema.labels.Salaries.incomeAmount", {
+			_locale: i18n.getLocale(),
+		}),
+		gender: i18n.__("SimpleSchema.labels.Salaries.gender", {
+			_locale: i18n.getLocale(),
+		}),
+		datePosted: i18n.__("SimpleSchema.labels.Salaries.datePosted", {
+			_locale: i18n.getLocale(),
+		}),
+	};
+};
 
 const salaryErrors = function(locale) {
 	return {
@@ -158,6 +176,8 @@ const salaryErrors = function(locale) {
 const englishSalaries = salaryErrors("en");
 const spanishSalaries = salaryErrors("es");
 
+Salaries.schema.labels(salaryLabels());
+
 Salaries.schema.messageBox.messages({
 	en: englishSalaries,
 	es: spanishSalaries,
@@ -166,6 +186,7 @@ Salaries.schema.messageBox.messages({
 i18n.onChangeLocale(function(newLocale) {
 	if (Meteor.isDevelopment) console.log("SALARIES: " + newLocale);
 	Salaries.schema.messageBox.setLanguage(newLocale);
+	Salaries.schema.labels(salaryLabels());
 });
 
 Salaries.attachSchema(Salaries.schema, { replace: true });

--- a/imports/api/data/salaries.js
+++ b/imports/api/data/salaries.js
@@ -155,15 +155,16 @@ const salaryErrors = function(locale) {
 	};
 };
 
+const englishSalaries = salaryErrors("en");
+const spanishSalaries = salaryErrors("es");
+
 Salaries.schema.messageBox.messages({
-	// en? does that mean we can add internationalization
-	// in this block of code?
-	en: salaryErrors("en"),
-	es: salaryErrors("es"),
+	en: englishSalaries,
+	es: spanishSalaries,
 });
 
 i18n.onChangeLocale(function(newLocale) {
-	console.log("SALARIES: " + newLocale);
+	if (Meteor.isDevelopment) console.log("SALARIES: " + newLocale);
 	Salaries.schema.messageBox.setLanguage(newLocale);
 });
 


### PR DESCRIPTION
Made the schema labels and error messages reactive with regards to locale, assuming that the following environment variable assignment is made:
UNIVERSE_I18N_LOCALES="en, es"

My wish list for these features:
- Not having to load all the locales on startup, but being able to load them as needed
- Being able to navigate to the forms for creating a company profile or posting a job without resetting locale, although I guess that's just as much integrating them into the session flow as anything else...