### PR TITLE
Iso8601 dates in graphql

### DIFF
--- a/imports/api/graphql/resolvers.js
+++ b/imports/api/graphql/resolvers.js
@@ -2,6 +2,8 @@
 /* eslint-disable no-unused-vars */
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
+import type { ValueNode } from "graphql/language";
+
 import type { Comment, CommentParent } from "../models/comment.js";
 import type { Company } from "../models/company.js";
 import type { JobAd } from "../models/job-ad.js";
@@ -300,17 +302,29 @@ export default {
 
 	Date: new GraphQLScalarType({
 		name: "Date",
-		parseValue(value: mixed): Date {
-			return new Date(value);
-		},
-		serialize(value: mixed): string {
-			return value.toISOString();
-		},
-		parseLiteral(ast) {
-			if (ast.kind === Kind.INT) {
-				return parseInt(ast.value, 10); // ast value is always in string format
+		serialize(value: mixed): ?string {
+			if (value instanceof Date) {
+				// TODO: Validate that Date instance is valid.
+				return value.toISOString();
 			}
-			return null;
+			// value is not a valid instance of Date.
+			return undefined;
+		},
+		parseValue(value: mixed): ?Date {
+			if (typeof value === "string" || value instanceof String) {
+				// TODO: Check for ISO 8601 format and reject all other formats.
+				return new Date(value);
+			}
+			// value is not a valid encoding for a Date scalar.
+			return undefined;
+		},
+		parseLiteral(ast: ValueNode): ?Date {
+			if (ast.kind === Kind.STRING) {
+				// TODO: Check for ISO 8601 format and reject all other formats.
+				return new Date(ast.value);
+			}
+			// value is not a valid encoding for a Date scalar.
+			return undefined;
 		},
 	}),
 };

--- a/imports/api/graphql/resolvers.js
+++ b/imports/api/graphql/resolvers.js
@@ -3,6 +3,7 @@
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
 import type { ValueNode } from "graphql/language";
+import { GraphQLDateTime } from "graphql-iso-date";
 
 import type { Comment, CommentParent } from "../models/comment.js";
 import type { Company } from "../models/company.js";
@@ -300,31 +301,5 @@ export default {
 			context.voteModel.getSubjectOfVote(obj),
 	},
 
-	Date: new GraphQLScalarType({
-		name: "Date",
-		serialize(value: mixed): ?string {
-			if (value instanceof Date) {
-				// TODO: Validate that Date instance is valid.
-				return value.toISOString();
-			}
-			// value is not a valid instance of Date.
-			return undefined;
-		},
-		parseValue(value: mixed): ?Date {
-			if (typeof value === "string" || value instanceof String) {
-				// TODO: Check for ISO 8601 format and reject all other formats.
-				return new Date(value);
-			}
-			// value is not a valid encoding for a Date scalar.
-			return undefined;
-		},
-		parseLiteral(ast: ValueNode): ?Date {
-			if (ast.kind === Kind.STRING) {
-				// TODO: Check for ISO 8601 format and reject all other formats.
-				return new Date(ast.value);
-			}
-			// value is not a valid encoding for a Date scalar.
-			return undefined;
-		},
-	}),
+	DateTime: GraphQLDateTime,
 };

--- a/imports/api/graphql/resolvers.js
+++ b/imports/api/graphql/resolvers.js
@@ -300,13 +300,11 @@ export default {
 
 	Date: new GraphQLScalarType({
 		name: "Date",
-		description:
-			"JavaScript Date serialized as milliseconds since midnight January 1, 1970 UTC.",
-		parseValue(value) {
-			return new Date(value); // value from the client
+		parseValue(value: mixed): Date {
+			return new Date(value);
 		},
-		serialize(value) {
-			return value.getTime(); // value sent to the client
+		serialize(value: mixed): string {
+			return value.toISOString();
 		},
 		parseLiteral(ast) {
 			if (ast.kind === Kind.INT) {

--- a/imports/api/graphql/schema.graphql
+++ b/imports/api/graphql/schema.graphql
@@ -182,4 +182,5 @@ type StarRatings {
 	overallSatisfaction: Float!
 }
 
+"Date and time serialized as a string in the ISO 8601 format."
 scalar Date

--- a/imports/api/graphql/schema.graphql
+++ b/imports/api/graphql/schema.graphql
@@ -35,7 +35,7 @@ type Comment {
 	"What was said in this comment."
 	content: String!
 	"The date and time this was created."
-	created: Date
+	created: DateTime
 
 	"The user who wrote this."
 	author: User!
@@ -52,14 +52,14 @@ type Company {
 
 	name: String!
 	contactEmail: String!
-	dateEstablished: Date
+	dateEstablished: DateTime
 	numEmployees: String
 	industry: String
 	locations: [String!]!
 	otherContactInfo: String
 	websiteURL: String
 	descriptionOfCompany: String
-	dateJoined: Date
+	dateJoined: DateTime
 	numFlags: Int
 	avgStarRatings: StarRatings
 	numReviews: Int!
@@ -84,7 +84,7 @@ type JobAd {
 	responsibilities: String!
 	qualifications: String!
 	"The date and time this was created."
-	created: Date
+	created: DateTime
 
 	"The company that is hiring."
 	company: Company!
@@ -103,7 +103,7 @@ type Review {
 	starRatings: StarRatings!
 	additionalComments: String
 	"The date and time this was created."
-	created: Date
+	created: DateTime
 	upvotes: Int
 	downvotes: Int
 
@@ -124,7 +124,7 @@ type Salary {
 	incomeType: String! # TODO change to enum
 	incomeAmount: Float! # TODO convert to unit aware system
 	"The date and time this was created."
-	created: Date
+	created: DateTime
 
 	"The user who submitted this."
 	author: User!
@@ -147,7 +147,7 @@ type User {
 	"The user's role."
 	role: UserRole!
 	"The date and time this was created."
-	created: Date!
+	created: DateTime!
 
 	"The company that this user is administering. Will be null if this user does not or can not admin a company."
 	company: Company
@@ -182,5 +182,6 @@ type StarRatings {
 	overallSatisfaction: Float!
 }
 
-"Date and time serialized as a string in the ISO 8601 format."
-scalar Date
+# Date and time serialized as a string in the ISO 8601 format.
+# Provided by graphql-iso-date on npm.
+scalar DateTime

--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,6 +2265,11 @@
         "source-map-support": "0.5.6"
       }
     },
+    "graphql-iso-date": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.5.0.tgz",
+      "integrity": "sha512-xs+8agn0OPzbiQf91aoyiZ3xC/oq4q/iJ4q1yY7hD0mbgcYBrqnZ4R+ycBZLGdb84rON1wNfqY4BDMyQG50OOg=="
+    },
     "graphql-server-express": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/graphql-server-express/-/graphql-server-express-1.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.16.3",
     "faker": "^4.1.0",
     "graphql": "^0.13.2",
+    "graphql-iso-date": "^3.5.0",
     "graphql-server-express": "^1.3.6",
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^3.0.2",


### PR DESCRIPTION
Changed the GraphQL API to encode dates and times as strings compliant with the date-time format outlined in the RFC 3339 profile of ISO 8601. For example `"2018-06-23T18:13:47Z"` is the time that I wrote this. 

JavaScript Date objects can be constructed directly from these strings.
```JavaScript
const myDate = new Date("2018-06-23T18:13:47Z");
```

As of yet, no code depends on this part of the API so nothing else was changed.