### PR TITLE
Post-a-job Form Bug Fixes

### DIFF
--- a/i18n/common/en.i18n.json
+++ b/i18n/common/en.i18n.json
@@ -77,6 +77,7 @@
 		},
 		"paj": {
 			"contractTypes": {
+				"default": "(Select One)",
 				"fullTime": "Full time",
 				"partTime": "Part time",
 				"contractor": "Contractor"

--- a/i18n/common/es.i18n.json
+++ b/i18n/common/es.i18n.json
@@ -79,7 +79,7 @@
 		},
 		"paj": {
 			"contractTypes": {
-				"default": "<PLEASE TRANSLATE> (Select One)",
+				"default": "(Seleccione uno)",
 				"fullTime": "Tiempo completo",
 				"partTime": "Medio tiempo",
 				"contractor": "Contratista"

--- a/i18n/common/es.i18n.json
+++ b/i18n/common/es.i18n.json
@@ -79,6 +79,7 @@
 		},
 		"paj": {
 			"contractTypes": {
+				"default": "<PLEASE TRANSLATE> (Select One)",
 				"fullTime": "Tiempo completo",
 				"partTime": "Medio tiempo",
 				"contractor": "Contratista"

--- a/imports/api/data/jobads.js
+++ b/imports/api/data/jobads.js
@@ -108,11 +108,7 @@ JobAds.schema = new SimpleSchema(
 		contractType: {
 			type: String,
 			optional: false,
-			allowedValues: [
-				i18n.__("common.forms.paj.contractTypes.fullTime"),
-				i18n.__("common.forms.paj.contractTypes.partTime"),
-				i18n.__("common.forms.paj.contractTypes.contractor"),
-			],
+			allowedValues: ["Full time", "Part time", "Contractor"],
 		},
 		jobDescription: {
 			type: String,

--- a/imports/ui/forms/post-a-job.html
+++ b/imports/ui/forms/post-a-job.html
@@ -14,7 +14,6 @@
 							   <br>
 							   <h4>Reach hundreds of workers instantly with our job posts</h4>
 							</div>
-							<form class="form-horizontal"  method="POST" action="#" >
 							   <fieldset>
 								   <div style="margin-left: 0" class="form-group {{#if afFieldIsInvalid name='companyName'}}has-error{{/if}}">
 
@@ -67,7 +66,6 @@
 									 </div>
 								  </div>
 							   </fieldset>
-							</form>
 						 </content>
 					  </div>
 				   </div>

--- a/imports/ui/forms/post-a-job.html
+++ b/imports/ui/forms/post-a-job.html
@@ -40,7 +40,7 @@
 								  </div>
 								  <div class="form-group {{#if afFieldIsInvalid name='contractType'}}has-error{{/if}}">
 									 <div class="col-lg-12">
-										{{> afQuickField name='contractType' options='allowed'}}
+										{{> afQuickField name='contractType' options=getContractTypeOptions firstOption=(__ ".paj.contractTypes.default")}}
 									 </div>
 								  </div>
 								  <div class="form-group {{#if afFieldIsInvalid name='jobDescription'}}has-error{{/if}}">

--- a/imports/ui/pages/post-a-job.jsx
+++ b/imports/ui/pages/post-a-job.jsx
@@ -54,6 +54,22 @@ if (Meteor.isClient) {
 			}
 			return company.name;
 		},
+		getContractTypeOptions() {
+			return [
+				{
+					label: i18n.__("common.forms.paj.contractTypes.fullTime"),
+					value: "Full time",
+				},
+				{
+					label: i18n.__("common.forms.paj.contractTypes.partTime"),
+					value: "Part time",
+				},
+				{
+					label: i18n.__("common.forms.paj.contractTypes.contractor"),
+					value: "Contractor",
+				},
+			];
+		},
 		hasError() {
 			return paj_form_state.get("formError") !== "good";
 		},


### PR DESCRIPTION
There were two bugs that we (mostly me) failed to catch on Julian's pull request:
- Contract type translations not loading
- Form submission not taking place
- Form error reporting not looking correct

Both have been fixed, but there may need to be additional work done before the form looks correct again:
- Contract type translations were fixed by having them loaded dynamically by a template helper function rather than statically by the schema
- However, this means a new translation will need to be added (you'll see which one if you try to translate the page)
- Form submission and error reporting were "fixed" by removing a form tag that seems to have overridden Autoform's default behaviors. This may require Julian going back through and finding a different way to apply styling to the page.