### PR TITLE
Migrate company search result to graphql

### DIFF
--- a/imports/api/graphql/resolvers.js
+++ b/imports/api/graphql/resolvers.js
@@ -180,12 +180,16 @@ export default {
 				args.pageNum,
 				args.pageSize
 			),
+		numJobAds: (obj: Company, args: PgnArgs, context: Context): number =>
+			context.jobAdModel.countJobAdsByCompany(obj),
 		salaries: (obj: Company, args: PgnArgs, context: Context) =>
 			context.salaryModel.getSalariesByCompany(
 				obj,
 				args.pageNum,
 				args.pageSize
 			),
+		numSalaries: (obj: Company, args: PgnArgs, context: Context): number =>
+			context.salaryModel.countSalariesByCompany(obj),
 	},
 
 	JobAd: {

--- a/imports/api/graphql/schema.graphql
+++ b/imports/api/graphql/schema.graphql
@@ -62,15 +62,21 @@ type Company {
 	dateJoined: DateTime
 	numFlags: Int
 	avgStarRatings: StarRatings
-	numReviews: Int!
 	percentRecommended: Float
 	avgNumMonthsWorked: Float
 
 	"Reviews about this company."
 	reviews(pageNum: Int, pageSize: Int): [Review!]!
+	"Number of reviews about this company."
+	numReviews: Int!
 	"Advertisements for jobs at this company."
 	jobAds(pageNum: Int, pageSize: Int): [JobAd!]!
+	"Number of advertisements for jobs at this company."
+	numJobAds: Int!
+	"Salaries reported to be earned at this company."
 	salaries(pageNum: Int, pageSize: Int): [Salary!]!
+	"Number of salaries reported to be earned at this company."
+	numSalaries: Int!
 }
 
 type JobAd {

--- a/imports/api/models/job-ad.js
+++ b/imports/api/models/job-ad.js
@@ -59,6 +59,13 @@ export default class JobAdModel {
 		return this.companyModel.getCompanyByName(jobAd.companyName);
 	}
 
+	// Count the number of job ads posted by a given company.
+	countJobAdsByCompany(company: Company): number {
+		const cursor = this.connector.find({ companyName: company.name });
+
+		return cursor.count();
+	}
+
 	// Get all of the job ads.
 	getAllJobAds(
 		pageNumber: number = 0,

--- a/imports/api/models/salary.js
+++ b/imports/api/models/salary.js
@@ -78,6 +78,13 @@ export default class SalaryModel {
 		return this.companyModel.getCompanyByName(salary.companyName);
 	}
 
+	// Count the number of salaries paid by a given company.
+	countSalariesByCompany(company: Company): number {
+		const cursor = this.connector.find({ companyName: company.name });
+
+		return cursor.count();
+	}
+
 	// Get all of the salaries.
 	getAllSalaries(
 		pageNumber: number = 0,

--- a/imports/ui/components/company-search-result.jsx
+++ b/imports/ui/components/company-search-result.jsx
@@ -2,12 +2,8 @@ import React from "react";
 import StarRatings from "react-star-ratings";
 import PropTypes from "prop-types";
 
-import { Meteor } from "meteor/meteor";
-import { withTracker } from "meteor/react-meteor-data";
 import i18n from "meteor/universe:i18n";
 
-import { JobAds } from "/imports/api/data/jobads.js";
-import { Salaries } from "/imports/api/data/salaries.js";
 import WriteReviewButton from "./write-review-button.jsx";
 
 const t = i18n.createTranslator("common.CompanySearchResult");
@@ -35,9 +31,7 @@ function CompanySearchResult(props) {
 					<div className="col-md-4  prostar">
 						<span className="goo">
 							{" "}
-							<a href={companyProfileUrl}>
-								{props.company.name}
-							</a>
+							<a href={companyProfileUrl}>{props.company.name}</a>
 						</span>
 						&nbsp;&nbsp;<StarRatings
 							rating={
@@ -75,7 +69,9 @@ function CompanySearchResult(props) {
 					<div className="col-md-5 prostar">
 						<div className="col-md-12">
 							<div className="titlestar">
-								<WriteReviewButton companyId={props.company.id} />
+								<WriteReviewButton
+									companyId={props.company.id}
+								/>
 							</div>
 						</div>
 					</div>
@@ -92,14 +88,14 @@ function CompanySearchResult(props) {
 									</span>
 								</li>
 								<li>
-									{props.salaries}
+									{props.company.numSalaries}
 									<br />
 									<span className="review_text">
 										<T>salaries</T>
 									</span>
 								</li>
 								<li>
-									{props.jobads}
+									{props.company.numJobAds}
 									<br />
 									<span className="review_text">
 										<T>jobs</T>
@@ -121,8 +117,6 @@ function CompanySearchResult(props) {
 }
 
 CompanySearchResult.propTypes = {
-	jobads: PropTypes.number.isRequired,
-	salaries: PropTypes.number.isRequired,
 	company: PropTypes.shape({
 		id: PropTypes.string.isRequired,
 		name: PropTypes.string.isRequired,
@@ -134,15 +128,9 @@ CompanySearchResult.propTypes = {
 			overallSatisfaction: PropTypes.number.isRequired,
 		}),
 		numReviews: PropTypes.number.isRequired,
+		numJobAds: PropTypes.number.isRequired,
+		numSalaries: PropTypes.number.isRequired,
 	}).isRequired,
 };
 
-export default withTracker(({ company }) => {
-	Meteor.subscribe("JobAds");
-	Meteor.subscribe("Salaries");
-
-	return {
-		jobads: JobAds.find({ companyName: company.name }).count(),
-		salaries: Salaries.find({ companyName: company.name }).count(),
-	};
-})(CompanySearchResult);
+export default CompanySearchResult;

--- a/imports/ui/pages/company-search-trial.jsx
+++ b/imports/ui/pages/company-search-trial.jsx
@@ -21,8 +21,10 @@ const companySearchQuery = gql`
 			locations
 			industry
 			numEmployees
-			numReviews
 			descriptionOfCompany
+			numReviews
+			numJobAds
+			numSalaries
 		}
 	}
 `;
@@ -43,7 +45,9 @@ const SearchResults = ({ searchText }) => (
 			}
 
 			const resultList = data.searchCompanies.map(function(company) {
-				return <CompanySearchResult key={company.id} company={company} />;
+				return (
+					<CompanySearchResult key={company.id} company={company} />
+				);
 			});
 
 			if (resultList.length < 1) {


### PR DESCRIPTION
* The company search result component has been migrated to GraphQL.
* The number of job ads and salaries are now queried through the company search trial with the rest of the data.
* The fields `numJobAds` and `numSalaries` have been added to the `Company` type in the GraphQL schema.