### PR TITLE
Refactor - Use module pattern for Header

### DIFF
--- a/imports/ui/components/header/employer-header.jsx
+++ b/imports/ui/components/header/employer-header.jsx
@@ -1,13 +1,15 @@
 import React from "react";
+
+import { Meteor } from "meteor/meteor";
 import i18n from "meteor/universe:i18n";
-import { If, Then, Else } from "../if-else.jsx";
-import LangSelector from "../components/lang-selector.jsx";
-import { urlGenerators } from "../../startup/client/router.jsx";
 import { withTracker } from "meteor/react-meteor-data";
+
+import { If, Then, Else } from "/imports/ui/if-else.jsx";
+import LangSelector from "./lang-selector.jsx";
 
 const T = i18n.createComponent();
 
-class WorkerHeader extends React.Component {
+class EmployerHeader extends React.Component {
 	render() {
 		return (
 			<div className="top-nav">
@@ -61,30 +63,24 @@ class WorkerHeader extends React.Component {
 									</If>
 								</li>
 								<li>
-									<a
-										href="/companies"
-										className="link-kumya "
-									>
-										<span>
-											<T>common.header.companies</T>
-										</span>
-									</a>
-								</li>
-								<li>
-									<a href="/jobs" className="link-kumya">
-										<span>
-											<T>common.header.jobs</T>
-										</span>
+									<a href="" className="link-kumya ">
+										<span>My Company</span>
 									</a>
 								</li>
 								<li>
 									<a
-										href="/worker-resources"
+										href="/post-a-job"
 										className="link-kumya"
 									>
-										<span>
-											<T>common.header.resources</T>
-										</span>
+										<span>Post a Job</span>
+									</a>
+								</li>
+								<li>
+									<a
+										href="/employer-resources"
+										className="link-kumya"
+									>
+										<span>Resources</span>
 									</a>
 								</li>
 							</ul>
@@ -106,7 +102,7 @@ class WorkerHeader extends React.Component {
 												<li className="tr">
 													<a
 														href="/my-account"
-														className="btn navbar-btn margin-right btn-green hvr-icon-forward"
+														className="link-kumya"
 													>
 														{i18n.__(
 															"common.header.myaccount"
@@ -116,7 +112,7 @@ class WorkerHeader extends React.Component {
 												<li className="tr">
 													<a
 														onClick={Meteor.logout}
-														className="navbar-link margin-right"
+														className="link-kumya"
 														style={{
 															cursor: "pointer",
 														}}
@@ -156,23 +152,13 @@ class WorkerHeader extends React.Component {
 								<li className="dropdown">
 									<LangSelector />
 								</li>
-								<li>
-									<a
-										href="/foremployers"
-										className="link-kumya"
-									>
-										<span>
-											<T>common.header.for_employers</T>
-										</span>
-									</a>
-								</li>
 								<br />
 								<If cond={this.props.isLoggedIn}>
 									<Then>
 										<li>
 											<a
 												onClick={Meteor.logout}
-												className="toggle-only-display navbar-link margin-right"
+												className="toggle-only-display link-kumya"
 												style={{ cursor: "pointer" }}
 											>
 												<T>common.header.logout</T>
@@ -193,4 +179,4 @@ class WorkerHeader extends React.Component {
 
 export default withTracker(() => ({
 	isLoggedIn: Meteor.userId() !== null,
-}))(WorkerHeader);
+}))(EmployerHeader);

--- a/imports/ui/components/header/header.jsx
+++ b/imports/ui/components/header/header.jsx
@@ -3,8 +3,8 @@ import React from "react";
 import { withTracker } from "meteor/react-meteor-data";
 import { Meteor } from "meteor/meteor";
 
-import WorkerHeader from "/imports/ui/components/workerHeader.jsx";
-import EmployerHeader from "/imports/ui/components/employerHeader.jsx";
+import WorkerHeader from "./worker-header.jsx";
+import EmployerHeader from "./employer-header.jsx";
 
 function Header(props) {
 	if (props.user) {

--- a/imports/ui/components/header/index.js
+++ b/imports/ui/components/header/index.js
@@ -1,0 +1,1 @@
+export { default } from "./header.jsx";

--- a/imports/ui/components/header/lang-selector.jsx
+++ b/imports/ui/components/header/lang-selector.jsx
@@ -4,13 +4,14 @@ import Dropdown, {
 	DropdownTrigger,
 	DropdownContent,
 } from "react-simple-dropdown";
+
 import { i18n } from "meteor/universe:i18n";
 import { withTracker } from "meteor/react-meteor-data";
 
 import {
 	localeMetadata,
 	reactiveGetLocale,
-} from "../../startup/client/i18n.js";
+} from "/imports/startup/client/i18n.js";
 
 function CurLang({ code }) {
 	return <img src={localeMetadata[code].icon} alt={`${code} icon.`} />;

--- a/imports/ui/components/header/worker-header.jsx
+++ b/imports/ui/components/header/worker-header.jsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { If, Then, Else } from "../if-else.jsx";
-import LangSelector from "../components/lang-selector.jsx";
+
+import { Meteor } from "meteor/meteor";
 import i18n from "meteor/universe:i18n";
-import { urlGenerators } from "../../startup/client/router.jsx";
 import { withTracker } from "meteor/react-meteor-data";
+
+import { If, Then, Else } from "/imports/ui/if-else.jsx";
+import LangSelector from "./lang-selector.jsx";
 
 const T = i18n.createComponent();
 
-class EmployerHeader extends React.Component {
+class WorkerHeader extends React.Component {
 	render() {
 		return (
 			<div className="top-nav">
@@ -61,24 +63,30 @@ class EmployerHeader extends React.Component {
 									</If>
 								</li>
 								<li>
-									<a href="" className="link-kumya ">
-										<span>My Company</span>
+									<a
+										href="/companies"
+										className="link-kumya "
+									>
+										<span>
+											<T>common.header.companies</T>
+										</span>
+									</a>
+								</li>
+								<li>
+									<a href="/jobs" className="link-kumya">
+										<span>
+											<T>common.header.jobs</T>
+										</span>
 									</a>
 								</li>
 								<li>
 									<a
-										href="/post-a-job"
+										href="/worker-resources"
 										className="link-kumya"
 									>
-										<span>Post a Job</span>
-									</a>
-								</li>
-								<li>
-									<a
-										href="/employer-resources"
-										className="link-kumya"
-									>
-										<span>Resources</span>
+										<span>
+											<T>common.header.resources</T>
+										</span>
 									</a>
 								</li>
 							</ul>
@@ -100,7 +108,7 @@ class EmployerHeader extends React.Component {
 												<li className="tr">
 													<a
 														href="/my-account"
-														className="link-kumya"
+														className="btn navbar-btn margin-right btn-green hvr-icon-forward"
 													>
 														{i18n.__(
 															"common.header.myaccount"
@@ -110,7 +118,7 @@ class EmployerHeader extends React.Component {
 												<li className="tr">
 													<a
 														onClick={Meteor.logout}
-														className="link-kumya"
+														className="navbar-link margin-right"
 														style={{
 															cursor: "pointer",
 														}}
@@ -150,13 +158,23 @@ class EmployerHeader extends React.Component {
 								<li className="dropdown">
 									<LangSelector />
 								</li>
+								<li>
+									<a
+										href="/foremployers"
+										className="link-kumya"
+									>
+										<span>
+											<T>common.header.for_employers</T>
+										</span>
+									</a>
+								</li>
 								<br />
 								<If cond={this.props.isLoggedIn}>
 									<Then>
 										<li>
 											<a
 												onClick={Meteor.logout}
-												className="toggle-only-display link-kumya"
+												className="toggle-only-display navbar-link margin-right"
 												style={{ cursor: "pointer" }}
 											>
 												<T>common.header.logout</T>
@@ -177,4 +195,4 @@ class EmployerHeader extends React.Component {
 
 export default withTracker(() => ({
 	isLoggedIn: Meteor.userId() !== null,
-}))(EmployerHeader);
+}))(WorkerHeader);

--- a/imports/ui/pages/about.jsx
+++ b/imports/ui/pages/about.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import { Meteor } from "meteor/meteor";
 import i18n from "meteor/universe:i18n";

--- a/imports/ui/pages/apply-for-job.jsx
+++ b/imports/ui/pages/apply-for-job.jsx
@@ -9,7 +9,7 @@ import { ReactiveDict } from "meteor/reactive-dict"; // used to hold global stat
 import { AutoForm } from "meteor/aldeed:autoform";
 import i18n from "meteor/universe:i18n";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 // Specific stuff second

--- a/imports/ui/pages/company-profile.jsx
+++ b/imports/ui/pages/company-profile.jsx
@@ -5,7 +5,7 @@ import { Query } from "react-apollo";
 import i18n from "meteor/universe:i18n";
 
 import ErrorBoundary from "/imports/ui/components/error-boundary.jsx";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 
 import CompanyProfileSummary from "/imports/ui/components/company-profile/summary.jsx";
 import OverviewTab from "/imports/ui/components/company-profile/tabs/overview.jsx";

--- a/imports/ui/pages/company-search-trial.jsx
+++ b/imports/ui/pages/company-search-trial.jsx
@@ -4,7 +4,7 @@ import i18n from "meteor/universe:i18n";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import CompanySearchResult from "/imports/ui/components/company-search-result.jsx";
 
 const t = i18n.createTranslator("common.search");

--- a/imports/ui/pages/contact-us.jsx
+++ b/imports/ui/pages/contact-us.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import { Meteor } from "meteor/meteor";
 

--- a/imports/ui/pages/foremployers.jsx
+++ b/imports/ui/pages/foremployers.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import i18n from "meteor/universe:i18n";
 

--- a/imports/ui/pages/home.jsx
+++ b/imports/ui/pages/home.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Meteor } from "meteor/meteor";
 import i18n from "meteor/universe:i18n";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import HomePageSearch from "../components/home-page-search.jsx";
 

--- a/imports/ui/pages/my-account.jsx
+++ b/imports/ui/pages/my-account.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Meteor } from "meteor/meteor";
 import { withTracker } from "meteor/react-meteor-data";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 /* The page where users can view their account details,

--- a/imports/ui/pages/password-changer.jsx
+++ b/imports/ui/pages/password-changer.jsx
@@ -5,7 +5,7 @@ import { withTracker } from "meteor/react-meteor-data";
 import { Accounts } from "meteor/accounts-base";
 import i18n from "meteor/universe:i18n";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 const t = i18n.createTranslator("common.passwordChanger");

--- a/imports/ui/pages/post-a-job.jsx
+++ b/imports/ui/pages/post-a-job.jsx
@@ -13,7 +13,7 @@ import { JobAds } from "../../api/data/jobads.js";
 import { Companies } from "../../api/data/companies.js";
 import "/imports/ui/forms/post-a-job.html";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 const paj_form_state = new ReactiveDict();

--- a/imports/ui/pages/resources-employers.jsx
+++ b/imports/ui/pages/resources-employers.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import { Meteor } from "meteor/meteor";
 import Modal from "react-modal";

--- a/imports/ui/pages/resources-workers.jsx
+++ b/imports/ui/pages/resources-workers.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 import { Meteor } from "meteor/meteor";
 import Modal from "react-modal";

--- a/imports/ui/pages/showjobs.jsx
+++ b/imports/ui/pages/showjobs.jsx
@@ -5,7 +5,7 @@ import { Query } from "react-apollo";
 import i18n from "meteor/universe:i18n";
 
 import ShowJobComponent from "/imports/ui/components/showJobComponent.jsx";
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 
 const T = i18n.createComponent();
 

--- a/imports/ui/pages/submit-salary-data.jsx
+++ b/imports/ui/pages/submit-salary-data.jsx
@@ -13,7 +13,7 @@ import { Salaries } from "../../api/data/salaries.js";
 import { Companies } from "../../api/data/companies.js";
 import "/imports/ui/forms/submit-salary-data.html";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 const ssd_form_state = new ReactiveDict();

--- a/imports/ui/pages/write-review.jsx
+++ b/imports/ui/pages/write-review.jsx
@@ -13,7 +13,7 @@ import { Reviews } from "../../api/data/reviews.js";
 import { Companies } from "../../api/data/companies.js";
 import "/imports/ui/forms/write-review.html";
 
-import Header from "/imports/ui/components/header.jsx";
+import Header from "/imports/ui/components/header";
 import Footer from "/imports/ui/components/footer.jsx";
 
 // Weird that I have to import both of these here,


### PR DESCRIPTION
In ES6 one can organize code into modules. All of the module's code is put in one directory and an `index.js` file is created. The `index.js` file exports all of the modules public members. When importing from a module the directory is put as the import path. This helps keep code more readable and maintainable by isolating unrelated files from each other.

I have organized the Header code into a module. 
* All of the files that are used only by the header are now in `/imports/ui/components/header`.
* None of the code was changed except for file renames and imports.
