### PR TITLE
Feature - Meteor Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# The config/settings files contain secrets and
+# should never be checked into version control.
+config
+
+# NPM stuff
 node_modules/
+
 # Mac stuff
 ._*
 

--- a/.meteorignore
+++ b/.meteorignore
@@ -1,0 +1,12 @@
+# The config/settings files contain secrets and
+# should never be loaded though a normal project build.
+# Also, different deployments may require different settings.
+config
+
+# Several scripts are used for things outside of Meteor such
+# as database initialization and continuous deployment.
+scripts
+
+# Documentation files such as README.md LICENSE.md
+# are not part of the project's code.
+*.md


### PR DESCRIPTION
Added a `.meteorignore` file to protect non-Meteor files from being loaded by Meteor. This works the same as a `.gitignore`. Also, the `config` and `script` directories have been preemptively setup. `config` contains the settings files which are kept out of version control and `scripts` is unpopulated at the moment but should soon get the database initialization scrips and automatic deployment scripts.