### PR TITLE
Bugfix - Get current user's vote, user not logged in

### DIFF
--- a/imports/api/graphql/resolvers.js
+++ b/imports/api/graphql/resolvers.js
@@ -15,7 +15,7 @@ import type { Vote, VoteSubject } from "../models/vote.js";
 import type { ID, AllModels } from "../models/common.js";
 
 type Context = {
-	user: User,
+	user?: User,
 } & AllModels;
 
 type PgnArgs = {
@@ -237,7 +237,9 @@ export default {
 				args.pageSize
 			),
 		currentUserVote: (obj: Review, args: {}, context: Context) =>
-			context.voteModel.getVoteByAuthorAndSubject(context.user, obj),
+			context.user
+				? context.voteModel.getVoteByAuthorAndSubject(context.user, obj)
+				: null,
 	},
 
 	Salary: {


### PR DESCRIPTION
Fixed error where when no user is logged in the API still tries to get the users current vote instead of returning `null` like it should. This caused all queries that fetch `Review.currentUserVote` to fail if the user was not logged in. Also fixed the `Context` type so that Flow will detect this kind of error in the future.