### PR TITLE
Bugfix - Remove pg-live-select

### DIFF
--- a/meteor-app/package.json
+++ b/meteor-app/package.json
@@ -38,7 +38,6 @@
     "message-box": "^0.2.0",
     "meteor-node-stubs": "^0.2.11",
     "pg": "^7.4.3",
-    "pg-live-select": "^1.0.3",
     "pg-native": "^3.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",


### PR DESCRIPTION
Removed pg-live-select because it is not needed.