### PR TITLE
Hotfix - lint-staged concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "chmod 755",
         "git add"
       ]
-    }
+    },
+    "concurrent": false
   },
   "devDependencies": {
     "@meteorjs/eslint-config-meteor": "^1.0.5",


### PR DESCRIPTION
By default lint-staged tries to run multiple linters at the same time. This causes the linters fail because only one `git add` command can be run at a time. I turned off this concurrency and it works fine now.